### PR TITLE
Add barebones vertx implementation and question the results

### DIFF
--- a/vertx/Dockerfile.vertx
+++ b/vertx/Dockerfile.vertx
@@ -1,0 +1,6 @@
+FROM hotswapagent/hotswap-vm
+COPY ./target/vertx-*.jar /work/application.jar
+ENV JAVA_OPTS "$JAVA_OPTS -Djava.net.preferIPv4Stack=true -Xmx128m"
+ENTRYPOINT java ${JAVA_OPTS} -cp /work/application -jar /work/application.jar
+WORKDIR /opt
+EXPOSE 8080 8000

--- a/vertx/build-vertx.sh
+++ b/vertx/build-vertx.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+mvn package  && docker build -f Dockerfile.vertx -t pingperf-vertx .

--- a/vertx/pom.xml
+++ b/vertx/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>pingperf</groupId>
+  <artifactId>vertx</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+
+  <name>pingperf</name>
+
+  <properties>
+    <vertx.verticle>pingperf.Main</vertx.verticle>
+
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.testSource>1.8</maven.compiler.testSource>
+    <maven.compiler.testTarget>1.8</maven.compiler.testTarget>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-stack-depchain</artifactId>
+        <version>3.7.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-core</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.reactiverse</groupId>
+        <artifactId>vertx-maven-plugin</artifactId>
+        <version>1.0.18</version>
+        <executions>
+          <execution>
+            <id>vmp</id>
+            <goals>
+              <goal>initialize</goal>
+              <goal>package</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <redeploy>true</redeploy>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/vertx/run-vertx.sh
+++ b/vertx/run-vertx.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker run -ti --rm -p 8080:8080 --network host pingperf-vertx

--- a/vertx/src/main/java/pingperf/Main.java
+++ b/vertx/src/main/java/pingperf/Main.java
@@ -1,0 +1,24 @@
+package pingperf;
+
+import io.vertx.core.AbstractVerticle;
+
+public class Main extends AbstractVerticle {
+
+    @Override
+    public void start() {
+        vertx
+        .createHttpServer()
+        .requestHandler(req -> {
+            if ("/simple".equals(req.path())) {
+                req.response()
+                    .end();
+            } else {
+                req.response()
+                    .setStatusCode(404)
+                    .end();
+            }
+        })
+        .listen(8080);
+    }
+
+}


### PR DESCRIPTION
I wanted to understand the results on the `README` which felt a bit incorrect, so I've implemented the benchmark in vert.x to have a reference, plus run it against: `Quarkus` and `Micronaut`.

### Micronaut:

```
Running 1m test @ http://127.0.0.1:8080/simple
  1 threads and 1 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    59.68us  189.28us   9.03ms   99.01%
    Req/Sec    20.81k     1.02k   22.01k    91.51%
  1244485 requests in 1.00m, 149.54MB read
Requests/sec:  20707.11
```

### Quarkus JVM:

```
Running 1m test @ http://127.0.0.1:8080/ping/simple
  1 threads and 1 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    26.08us   63.74us   6.11ms   99.32%
    Req/Sec    43.34k     1.59k   45.63k    89.02%
  2591544 requests in 1.00m, 93.92MB read
Requests/sec:  43121.04
```

### Vert.x:

```
Running 1m test @ http://127.0.0.1:8080/simple
  1 threads and 1 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    21.78us   30.75us   1.73ms   99.54%
    Req/Sec    46.98k     1.03k   49.55k    80.37%
  2809634 requests in 1.00m, 101.82MB read
Requests/sec:  46749.75
```

So on the first test single user as expected, vert.x wins, quarkus comes second (again as expected as it is using vert.x internally so, there is one more small layer of code to execute) and micronaut comes third (far from the second).

While running the the 50 users test:

### Micronaut:

```
Running 1m test @ http://127.0.0.1:8080/simple
  4 threads and 50 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.49ms    6.40ms 234.21ms   96.99%
    Req/Sec    18.23k     2.98k   26.64k    70.70%
  4353817 requests in 1.00m, 523.17MB read
Requests/sec:  72530.27
```

### Quarkus:

```
Running 1m test @ http://127.0.0.1:8080/ping/simple
  4 threads and 50 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   653.31us  249.45us  22.93ms   97.09%
    Req/Sec    18.58k     1.21k   28.02k    78.90%
  4443222 requests in 1.00m, 161.02MB read
Requests/sec:  73931.09
```

### Vert.x

```
Running 1m test @ http://127.0.0.1:8080/simple
  4 threads and 50 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   530.57us  269.65us  26.40ms   95.93%
    Req/Sec    22.79k     2.14k   30.58k    79.03%
  5450104 requests in 1.00m, 197.51MB read
Requests/sec:  90684.28
```

Now here again as expected vert.x wins by a large margin, quarkus and micronaut come second and third by this order but their difference is minimal (however on the readme the difference is way to large).

@johnaohara, @skybber I think you should review the results on the main page as they can be really misleading for users looking for basic performance comparisons.